### PR TITLE
Promotion of abuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# NI Tech & Design Slack Code of Conduct
+
+This Code of Conduct belongs to the NI Tech & Design Slack ("The Slack") -- a tech- and design-focussed Slack group loosely geographically based around Northern Ireland. The Code of Conduct is currently being maintained in the file `code-of-conduct.md` in https://github.com/nitechdesign/code-of-conduct/ ("This Repository")
+
+
+## Proposing Changes
+
+Changes can be proposed by any member of The Slack, and are accepted through the following mechanisms:
+
+- suggestions put forward in the `#code-of-conduct` channel in The Slack
+- directly messaging an admin in The Slack (see list of admins below)
+- raising an issue in This Repository
+- creating a pull request in This Repository
+
+At present, "anonymous" changes are accepted -- this is subject to change if the quality of anonymous changes degrades.
+
+
+## Acceptance of Proposed Changes
+
+Proposed changes to the Code of Conduct will go through a brief review process with the five admins (see list of admins below). A change can be merged under the following conditions:
+
+- the change has received **two** or more approvals from the admins (an approval is indicated by "Approved" in GitHub PR-speak)
+- if the change was created by an admin, the change most receive **three** or more approvals from the admins.
+- the change has not received any PR rejections from an admin (a rejection is indicated by "Request Changes" in GitHub PR-speak)
+
+
+## Admins
+
+Admins for The Slack are:
+
+- `bolster`
+- `clairebones`
+- `MarkXA`
+- `mo`
+- `victoria`

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,6 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Promotion of abuse, exclusion or harassment based on the characteristics above
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,7 +32,7 @@ Harassment:
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or politicial opinion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or political opinion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -13,7 +13,7 @@ We want this to be a fun, pleasant, and harassment-free experience for everyone,
 Confidentiality:
 ----------------
 
-**Please keep what's said in the NI Tech Slack confidential**. Don't repeat or quote things said here without the affirmative consent of the speaker(s). When quoting (with consent), please be careful not to reveal the existence of the NI Tech Slack. Rather, you can refer to the quote as something that was said "in chat" or while you were talking to the quoted member.
+**Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
 **Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,7 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to pub/controversy pieces accepting racist, sexist or homophic groups
+* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to publicity-raising or controversy pieces accepting racist, sexist or homophobic groups
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -6,7 +6,13 @@ Welcome!
 
 The NI Tech and Design Slack (or NI Tech Slack) is a gathering of people working in the tech and design fields with an association to Northern Ireland. The group is not restricted to people who work in these fields, or who live in Northern Ireland.
 
-The current admin is Maurice Kelly (@mo).
+The current admins are:
+
+- Andrew Bolster (@bolster)
+- Claire Wilgar (@clairebones)
+- Mark Allan (@MarkXA)
+- Maurice Kelly (@mo)
+- Victoria McCallum (@victoria)
 
 We want this to be a fun, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Participants asked to stop any harassing behaviour are expected to comply immediately.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -33,7 +33,7 @@ Harassment:
 Harassment includes:
 
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
-* Promotion of abuse, exclusion or harassment based on the characteristics above
+* Promotion of abuse, exclusion or harassment based on the characteristics above, like links or tweets to pub/controversy pieces accepting racist, sexist or homophic groups
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -15,12 +15,7 @@ Confidentiality:
 
 **Please respect the confidentiality of what is said in the NI Tech Slack**. The Slack is open to all who wish to join, but the messages posted are only visible to those who join. Members have a right to expect that their postings are not replicated widely without their approval. Please don't repeat or quote things said here without the affirmative consent of the member(s).
 
-**Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
-
-Logs and Records:
------------------
-
-**Please be mindful that things you say here may at some point become public**. We cannot prevent people from screencapping or otherwise logging this slack. We also can't guarantee that every member's login credentials and logged-in devices are secure. Files uploaded here can be downloaded by anyone with a login. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
+**Please be mindful that things you say here may at some point become public**. Notwithstanding the above, we cannot guarantee that messages posted will not be seen be non-members, nor by people who become members in the future. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 
 Message Retention:
 ------------------

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -32,7 +32,7 @@ Harassment:
 
 Harassment includes:
 
-* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
+* Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, religion or politicial opinion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
 * Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -8,14 +8,14 @@ The NI Tech and Design Slack (or NI Tech Slack) is a gathering of people working
 
 The current admin is Maurice Kelly (@mo).
 
-We want this to be a fun, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Participants asked to stop any harassing behavior are expected to comply immediately.
+We want this to be a fun, pleasant, and harassment-free experience for everyone, regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, or religion. We do not tolerate harassment of participants in any form. Participants asked to stop any harassing behaviour are expected to comply immediately.
 
 Confidentiality:
 ----------------
 
 **Please keep what's said in the NI Tech Slack confidential**. Don't repeat or quote things said here without the affirmative consent of the speaker(s). When quoting (with consent), please be careful not to reveal the existence of the NI Tech Slack. Rather, you can refer to the quote as something that was said "in chat" or while you were talking to the quoted member.
 
-**Please be mindful that things you say here may at some point become public**. While we expect members to honor the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
+**Please be mindful that things you say here may at some point become public**. While we expect members to honour the confidentiality of this space, we cannot guarantee that they will do so--nor can we guarantee that every member's login credentials and logged-in devices are secure. Please exercise caution and refrain from sharing sensitive information that could harm you or others if it became public.
 
 Logs and Records:
 -----------------
@@ -35,7 +35,7 @@ Harassment includes:
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, or religion
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.
 * Deliberate misgendering or use of ‘dead’ or rejected names
-* Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate
+* Gratuitous or off-topic sexual images or behaviour in spaces where they’re not appropriate
 * Simulated physical contact (e.g. textual descriptions like “*hug*” or “*backrub*”) without consent or after a request to stop.
 * Threats of violence
 * Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
@@ -55,9 +55,9 @@ We will respect confidentiality requests for the purpose of protecting victims o
 Consequences
 ------------
 
-Participants asked to stop any harassing behavior are expected to comply immediately.
+Participants asked to stop any harassing behaviour are expected to comply immediately.
 
-If a participant engages in harassing behavior, the admins may take any action they deem appropriate, up to and including expulsion from this slack and identifying the participant publicly as someone about whom we've received complaints.
+If a participant engages in harassing behaviour, the admins may take any action they deem appropriate, up to and including expulsion from this slack and identifying the participant publicly as someone about whom we've received complaints.
 
 Credits and License
 --------------------


### PR DESCRIPTION
"Offensive comments" is too vague to call out promoting discrimination (like links or tweets to pub/controversy pieces by racist, sexist or homophic groups), that hide under "free speech". This backs us up in rejecting that kind of content when admins see it's necessary.

Could be in different place in list, but then needs characteristics list copied.